### PR TITLE
Update NA String Logic

### DIFF
--- a/internal/characters/mavuika/attack.go
+++ b/internal/characters/mavuika/attack.go
@@ -110,12 +110,8 @@ func (c *char) Attack(p map[string]int) (action.Info, error) {
 	}, nil
 }
 
-// Mavuika's bike normals do not immediately reset after sprinting and will carry the counter upon losing NS Blessing
+// Mavuika's bike normals do not immediately reset after sprinting and will carry the counter upon losing NS Blessing (Handled in Dash)
 func (c *char) bikeAttack() action.Info {
-	switch c.Core.Player.CurrentState() {
-	case action.DashState:
-		c.NormalCounter = c.savedNormalCounter
-	}
 	delay := bikeAttackHitmarks[c.NormalCounter]
 	ai := combat.AttackInfo{
 		ActorIndex:       c.Index,

--- a/internal/characters/mavuika/dash.go
+++ b/internal/characters/mavuika/dash.go
@@ -30,6 +30,10 @@ func (c *char) Dash(p map[string]int) (action.Info, error) {
 		)
 		c.Core.QueueAttack(ai, ap, 6, 6)
 		c.reduceNightsoulPoints(10)
+		// If dashing from NA while in bike, do not reset NA string
+		if c.Core.Player.CurrentState() == action.NormalAttackState {
+			c.savedNormalCounter = c.NormalCounter
+		}
 	}
 
 	return c.Character.Dash(p)

--- a/internal/characters/mavuika/skill.go
+++ b/internal/characters/mavuika/skill.go
@@ -156,10 +156,8 @@ func (c *char) exitBike() {
 	c.NormalHitNum = normalHitNum
 	c.ringSrc = c.Core.F
 
-	if c.nightsoulState.HasBlessing() {
-		c.QueueCharTask(c.skillRing(c.ringSrc), 120)
-		c.c2Ring()
-	}
+	c.QueueCharTask(c.skillRing(c.ringSrc), 120)
+	c.c2Ring()
 }
 
 func (c *char) skillRecast() action.Info {


### PR DESCRIPTION
Moved saving normal counter to dash, which is the only action that would do so. Initial implementation had bugs with the combo N1 CA Dash N1 not resetting the string.