### PR TITLE
Update charge, dash, docs

### DIFF
--- a/internal/characters/mavuika/charge.go
+++ b/internal/characters/mavuika/charge.go
@@ -643,11 +643,10 @@ func (*char) GetHittableEntityList() []HittableEntity {
 // Iterate through CA frames, starting at hitmark
 func (c *char) CalculateValidCollisionFrames(durationCA int, collisionFrames [2]int, lastHitFrame int) []int {
 	validFrames := []int{}
-	currentFrame := bikeChargeAttackStartupHitmark // Spin hitbox starts on frame 35 of CA anim (full windup)
-	var timeSinceStart int
+	currentFrame := bikeChargeAttackStartupHitmark // Spin hitbox starts on frame 35 of CA anim (full windup)	var timeSinceStart int
 
 	// Check if CA is continuing from previous action, adjust current cycle
-	timeSinceStart = c.Core.F - (c.caState.StartFrame - c.caState.skippedWindupF)
+	timeSinceStart := c.Core.F - (c.caState.StartFrame - c.caState.skippedWindupF)
 	timeSinceLastHit := timeSinceStart - lastHitFrame
 	if timeSinceStart >= currentFrame {
 		currentFrame = timeSinceStart
@@ -716,7 +715,7 @@ func (c *char) BikeHitboxIntersectionAngles(v combat.Target, f []int, offsetAngl
 	case *geometry.Circle:
 		enemyRadius = v.Radius() // Rt
 	default:
-		return false, errors.New("target has non-circular hitbox, Mavuika CA requires circle hitboxes for calculations.")
+		return false, errors.New("target has non-circular hitbox, Mavuika CA requires circle hitboxes for calculations")
 	}
 
 	bikeInnerRadius := bikeChargeAttackSpinOffset - bikeChargeAttackHitboxRadius // Ri

--- a/internal/characters/mavuika/dash.go
+++ b/internal/characters/mavuika/dash.go
@@ -1,12 +1,25 @@
 package mavuika
 
 import (
+	"github.com/genshinsim/gcsim/internal/frames"
 	"github.com/genshinsim/gcsim/pkg/core/action"
 	"github.com/genshinsim/gcsim/pkg/core/attacks"
 	"github.com/genshinsim/gcsim/pkg/core/attributes"
 	"github.com/genshinsim/gcsim/pkg/core/combat"
 	"github.com/genshinsim/gcsim/pkg/core/geometry"
 )
+
+var dashFrames []int
+
+func init() {
+	dashFrames = frames.InitAbilSlice(24) // Dash -> Dash
+	dashFrames[action.ActionAttack] = 18
+	dashFrames[action.ActionCharge] = 20
+	dashFrames[action.ActionSkill] = 20
+	dashFrames[action.ActionBurst] = 20
+	dashFrames[action.ActionSwap] = 0
+	dashFrames[action.ActionJump] = 0
+}
 
 func (c *char) Dash(p map[string]int) (action.Info, error) {
 	if c.armamentState == bike && c.nightsoulState.HasBlessing() {
@@ -23,6 +36,7 @@ func (c *char) Dash(p map[string]int) (action.Info, error) {
 			Durability:     25,
 			Mult:           skillDash[c.TalentLvlSkill()],
 			HitlagFactor:   0.05,
+			IsDeployable:   true,
 		}
 		ap := combat.NewCircleHitOnTarget(
 			c.Core.Combat.Player(),
@@ -35,6 +49,15 @@ func (c *char) Dash(p map[string]int) (action.Info, error) {
 		if c.Core.Player.CurrentState() == action.NormalAttackState {
 			c.savedNormalCounter = c.NormalCounter
 		}
+
+		// Execute dash CD logic
+		c.ApplyDashCD()
+		return action.Info{
+			Frames:          frames.NewAbilFunc(dashFrames),
+			AnimationLength: dashFrames[action.InvalidAction],
+			CanQueueAfter:   dashFrames[action.ActionJump],
+			State:           action.DashState,
+		}, nil
 	}
 
 	return c.Character.Dash(p)

--- a/ui/packages/docs/src/components/Actions/character_data.json
+++ b/ui/packages/docs/src/components/Actions/character_data.json
@@ -1808,6 +1808,48 @@
       "legal": true
     }
   ],
+  "mavuika": [
+    {
+      "ability": "attack",
+      "legal": true
+    },
+    {
+      "ability": "charge",
+      "legal": true
+    },
+    {
+      "ability": "skill",
+      "legal": true
+    },
+    {
+      "ability": "burst",
+      "legal": true
+    },
+    {
+      "ability": "low_plunge",
+      "notes": "Previous action must be a walking Flamestrider jump or jump buffed via Xianyun's burst for example."
+    },
+    {
+      "ability": "high_plunge",
+      "notes": "Previous action must be a jump buffed via Xianyun's burst for example."
+    },
+    {
+      "ability": "dash",
+      "legal": true
+    },
+    {
+      "ability": "jump",
+      "legal": true
+    },
+    {
+      "ability": "walk",
+      "legal": true
+    },
+    {
+      "ability": "swap",
+      "legal": true
+    }
+  ],
   "mika": [
     {
       "ability": "attack",

--- a/ui/packages/docs/src/components/Frames/character_data.json
+++ b/ui/packages/docs/src/components/Frames/character_data.json
@@ -971,6 +971,14 @@
       "count": "https://docs.google.com/spreadsheets/d/1gnA8r59Zp4gMIWTeOyW04hUikeNyrHIL7Ujbc-QATjs/edit?usp=sharing"
     }
   ],
+  "mavuika": [
+    {
+      "vid_credit": "aftermathrar",
+      "count_credit": "aftermathrar",
+      "vid": "https://www.youtube.com/playlist?list=PLR5JbgmY4L_TBQ13IzYvVvfKZkk-ypM3t",
+      "count": "https://docs.google.com/spreadsheets/d/1HmsTvcv127qYflBtgjV8-4-ldteXGcDFdUv9JnyFz2o/edit?usp=sharing"
+    }
+  ],
   "mika": [
     {
       "vid_credit": "Kolibri#7675",

--- a/ui/packages/docs/src/components/Params/character_data.json
+++ b/ui/packages/docs/src/components/Params/character_data.json
@@ -822,6 +822,43 @@
       "desc": "Hit weakspot with aimed shot. Default 0 (false), 1 for true."
     }
   ],
+  "mavuika": [
+    {
+      "ability": "charge",
+      "param": "hold",
+      "desc": "Number of frames to extend Charge Attack by. Min 1, max 45, can only be used after a Charge attack has started."
+    },
+    {
+      "ability": "charge",
+      "param": "final",
+      "desc": "Used to explicitly initiate the Flamestrider's final hit of the charge attack."
+    },
+    {
+      "ability": "charge",
+      "param": "buffered",
+      "desc": "Number of frames to buffer CA. Range 0-15, lower values can be used to trigger certain N0 abilities."
+    },
+    {
+      "ability": "skill",
+      "param": "hold",
+      "desc": "0 for Tap (default), 1 for Hold."
+    },
+    {
+      "ability": "skill",
+      "param": "recast",
+      "desc": "0 to use E (default), 1 to use Recast E. Recast E is only possible if Nightsoul Blessing is active and Recast E is not on cooldown."
+    },
+    {
+      "ability": "low_plunge",
+      "param": "collision",
+      "desc": "0 for no collision dmg (default), 1 for collision dmg. Flamestrider plunge has no collision."
+    },
+    {
+      "ability": "high_plunge",
+      "param": "collision",
+      "desc": "0 for no collision dmg (default), 1 for collision dmg. Flamestrider plunge has no collision."
+    }
+  ],
   "mika": [
     {
       "ability": "skill",


### PR DESCRIPTION
Updated docs for Mavuika's actions and params.
Added bike dash handling for specific frame counts. 
Added an error when a target has a hitbox shape that does not work with the CA calculation. 
Changed hook timing to capture dendro cores that spawn during windup. Updated comments.
Fixed CAF not meeting the minimum CA duration if used as the first action.
Added 'buffered' param to allow for delaying CA after burst in order to proc N0 triggers.